### PR TITLE
Increasing supported Python version to include 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(name='pyhandle',
           'pymysql',
       ],
       tests_require=test_dependencies,
-      python_requires='>=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.8',
+      python_requires='>=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.10',
       cmdclass={'test': NoseTestCommand},
       include_package_data=True
 )


### PR DESCRIPTION
I wasn't able to install pyhandle for python 3.9. Increasing the maximum so that it becomes `<3.10` and ran the tests, which all succeeded. So I assume this change is enough to support current Pythin versions. 