### PR TITLE
Issue40, only slight addition.

### DIFF
--- a/pyhandle/client/resthandleclient.py
+++ b/pyhandle/client/resthandleclient.py
@@ -553,6 +553,7 @@ class RESTHandleClient(HandleClient):
             # delete and process response:
             op = 'deleting "' + str(keys) + '"'
             resp = self.__send_handle_delete_request(handle, indices=indices, op=op)
+
             if hsresponses.handle_success(resp):
                 LOGGER.debug("delete_handle_value: Deleted handle values " + str(keys) + "of handle " + handle)
                 return json.loads(decoded_response(resp))['handle']
@@ -565,8 +566,6 @@ class RESTHandleClient(HandleClient):
                     handle=handle,
                     response=resp
                 )
-                
-    
 
     def delete_handle(self, handle, *other):
         '''Delete the handle and its handle record. If the Handle is not found, an Exception is raised.
@@ -595,17 +594,20 @@ class RESTHandleClient(HandleClient):
 
         op = 'deleting handle'
         resp = self.__send_handle_delete_request(handle, op=op)
+        handle = json.loads(decoded_response(resp))['handle']
+
         if hsresponses.handle_success(resp):
+            # Response: {'handle': '21.14106/TESTTESTTEST', 'responseCode': 1}   with HTTP 200
             LOGGER.info('Handle ' + handle + ' deleted.')
-            return json.loads(decoded_response(resp))['handle']
+            return handle
         elif hsresponses.handle_not_found(resp):
+            # Response: {'handle': '21.14106/TESTTESTTEST', 'responseCode': 100} with HTTP 404
             msg = ('delete_handle: Handle ' + handle + ' did not exist, '
                    'so it could not be deleted.')
             LOGGER.debug(msg)
             raise HandleNotFoundException(msg=msg, handle=handle, response=resp)
         else:
             raise GenericHandleError(op=op, handle=handle, response=resp)
-
 
     def register_handle_json(self, handle, list_of_entries, overwrite=False):
         '''

--- a/pyhandle/client/resthandleclient.py
+++ b/pyhandle/client/resthandleclient.py
@@ -500,7 +500,7 @@ class RESTHandleClient(HandleClient):
                     payload=put_payload
                 )
                 
-        return handle
+        return json.loads(decoded_response(resp))['handle']
 
     def delete_handle_value(self, handle, key):
         '''
@@ -555,7 +555,8 @@ class RESTHandleClient(HandleClient):
             resp = self.__send_handle_delete_request(handle, indices=indices, op=op)
             if hsresponses.handle_success(resp):
                 LOGGER.debug("delete_handle_value: Deleted handle values " + str(keys) + "of handle " + handle)
-                return handle
+                return json.loads(decoded_response(resp))['handle']
+
             elif hsresponses.values_not_found(resp):
                 pass
             else:
@@ -596,7 +597,7 @@ class RESTHandleClient(HandleClient):
         resp = self.__send_handle_delete_request(handle, op=op)
         if hsresponses.handle_success(resp):
             LOGGER.info('Handle ' + handle + ' deleted.')
-            return handle
+            return json.loads(decoded_response(resp))['handle']
         elif hsresponses.handle_not_found(resp):
             msg = ('delete_handle: Handle ' + handle + ' did not exist, '
                    'so it could not be deleted.')

--- a/pyhandle/tests/mockresponses.py
+++ b/pyhandle/tests/mockresponses.py
@@ -42,10 +42,11 @@ class MockResponse(object):
             self.content = '{"responseCode":1, "handle":"my/testhandle"}'
         elif notfound:
             self.status_code = 404
-            self.content = '{"responseCode":100}'
+            self.content = '{"responseCode":100, "handle":"my/testhandle"}'
+            # This response to a delete-handle request was verified 2022-06-28 by Merret
         elif empty:
             self.status_code = 200
-            self.content = '{"responseCode":200}'
+            self.content = '{"responseCode":200, "handle":"my/testhandle"}'
         elif wascreated:
             self.status_code = 201
             self.content = '{"responseCode":1, "handle":"my/testhandle"}'
@@ -58,7 +59,7 @@ class MockResponse(object):
             self.request = request
         # Defaults (they do not override):
         if self.content is None:    
-            self.content = '{"responseCode":1}'
+            self.content = '{"responseCode":1, "handle":"my/testhandle"}'
         if self.status_code is None:
             self.status_code = 200
         if self.request is None:


### PR DESCRIPTION
Follow-up for Pull Request #60  https://github.com/EUDAT-B2HANDLE/PYHANDLE/pull/60 .

Instead of just returning the handle, we now return the handle that was returned by the handle server. These should be the same (otherwise we're in trouble anyway), but it might be slightly different in terms of `hdl:` or `doi:` being prepended or removed.