### PR TITLE
Make sure syntax checks are not passed for strings like '301:prefix/suffix'

### DIFF
--- a/pyhandle/utilhandle.py
+++ b/pyhandle/utilhandle.py
@@ -64,13 +64,11 @@ def check_handle_syntax(string):
 
     if ':' in string:
         if string.startswith('hdl:'): # Fixing https://github.com/EUDAT-B2HANDLE/PYHANDLE/issues/49
-            # TODO: Note: What about DOIs?
             # TODO: Note of caution: Handle Server won't accept REST API calls with hdl: prepended.
             return True
-        else:
-            check_handle_syntax_with_index(string, base_already_checked=True)
-            # TODO: Actually this is not a handle, but refers to a field inside a handle record, so
-            # to be strict, we should not accept this.
+        elif string.startswith('doi:'):
+            # TODO: Note of caution: Handle Server won't accept REST API calls with doi: prepended.
+            return True
 
     return True
 


### PR DESCRIPTION
Addressing issue #49 , second part.

This is a follow up to PR #58 https://github.com/EUDAT-B2HANDLE/PYHANDLE/pull/58

Now, if you run a syntax check (`check_handle_syntax()`) over a handle `301:prefix/suffix`, it will fail. Because this is not a handle, this is a reference to a field in a handle record. For this, the method `check_handle_syntax_with_index()` exists.