### PR TITLE
Issue25: Gracefully deal with handle strings starting with `hdl:` or `doi:`

### DIFF
--- a/pyhandle/client/resthandleclient.py
+++ b/pyhandle/client/resthandleclient.py
@@ -270,7 +270,8 @@ class RESTHandleClient(HandleClient):
         elif hsresponses.does_handle_exist(response):
          
             handlerecord_json = json.loads(response_content)
-            if not handlerecord_json['handle'] == handle:
+
+            if not handlerecord_json['handle'] == handle.lstrip('hdl:').lstrip('doi:'):
                 raise GenericHandleError(
                     operation='retrieving handle record',
                     handle=handle,

--- a/pyhandle/client/resthandleclient.py
+++ b/pyhandle/client/resthandleclient.py
@@ -553,6 +553,7 @@ class RESTHandleClient(HandleClient):
             # delete and process response:
             op = 'deleting "' + str(keys) + '"'
             resp = self.__send_handle_delete_request(handle, indices=indices, op=op)
+
             if hsresponses.handle_success(resp):
                 LOGGER.debug("delete_handle_value: Deleted handle values " + str(keys) + "of handle " + handle)
                 return json.loads(decoded_response(resp))['handle']
@@ -565,8 +566,6 @@ class RESTHandleClient(HandleClient):
                     handle=handle,
                     response=resp
                 )
-                
-    
 
     def delete_handle(self, handle, *other):
         '''Delete the handle and its handle record. If the Handle is not found, an Exception is raised.
@@ -595,17 +594,20 @@ class RESTHandleClient(HandleClient):
 
         op = 'deleting handle'
         resp = self.__send_handle_delete_request(handle, op=op)
+        handle = json.loads(decoded_response(resp))['handle']
+
         if hsresponses.handle_success(resp):
+            # Response: {'handle': '21.14106/TESTTESTTEST', 'responseCode': 1}   with HTTP 200
             LOGGER.info('Handle ' + handle + ' deleted.')
-            return json.loads(decoded_response(resp))['handle']
+            return handle
         elif hsresponses.handle_not_found(resp):
+            # Response: {'handle': '21.14106/TESTTESTTEST', 'responseCode': 100} with HTTP 404
             msg = ('delete_handle: Handle ' + handle + ' did not exist, '
                    'so it could not be deleted.')
             LOGGER.debug(msg)
             raise HandleNotFoundException(msg=msg, handle=handle, response=resp)
         else:
             raise GenericHandleError(op=op, handle=handle, response=resp)
-
 
     def register_handle_json(self, handle, list_of_entries, overwrite=False):
         '''

--- a/pyhandle/client/resthandleclient.py
+++ b/pyhandle/client/resthandleclient.py
@@ -500,7 +500,7 @@ class RESTHandleClient(HandleClient):
                     payload=put_payload
                 )
                 
-        return handle
+        return json.loads(decoded_response(resp))['handle']
 
     def delete_handle_value(self, handle, key):
         '''
@@ -555,7 +555,8 @@ class RESTHandleClient(HandleClient):
             resp = self.__send_handle_delete_request(handle, indices=indices, op=op)
             if hsresponses.handle_success(resp):
                 LOGGER.debug("delete_handle_value: Deleted handle values " + str(keys) + "of handle " + handle)
-                return handle
+                return json.loads(decoded_response(resp))['handle']
+
             elif hsresponses.values_not_found(resp):
                 pass
             else:
@@ -596,7 +597,7 @@ class RESTHandleClient(HandleClient):
         resp = self.__send_handle_delete_request(handle, op=op)
         if hsresponses.handle_success(resp):
             LOGGER.info('Handle ' + handle + ' deleted.')
-            return handle
+            return json.loads(decoded_response(resp))['handle']
         elif hsresponses.handle_not_found(resp):
             msg = ('delete_handle: Handle ' + handle + ' did not exist, '
                    'so it could not be deleted.')

--- a/pyhandle/handlesystemconnector.py
+++ b/pyhandle/handlesystemconnector.py
@@ -261,7 +261,6 @@ class HandleSystemConnector(object):
         :return: The server's response.
         '''
 
-
         # Assemble required info:
         url = self.make_handle_URL(handle, indices)
         LOGGER.debug('GET Request to '+url)
@@ -295,7 +294,6 @@ class HandleSystemConnector(object):
             return True
         else:
             return False
-
 
     def send_handle_put_request(self, **args):
         '''
@@ -536,6 +534,12 @@ class HandleSystemConnector(object):
         '''
         LOGGER.debug('make_handle_URL...')
         separator = '?'
+
+        # Handle Server does not accept REST API requests with "hdl:" nor "doi:",
+        # it interprets them as part of the prefix.
+        # It will respond with HTTP Status Code 400 and Response: {"responseCode":301,
+        # "message":"That prefix doesn't live here","handle":"hdl:21.14106/TESTTESTTEST"}
+        handle = handle.lstrip('hdl:').lstrip('doi:')
 
         if other_url is not None:
             url = other_url

--- a/pyhandle/tests/mockresponses.py
+++ b/pyhandle/tests/mockresponses.py
@@ -30,13 +30,15 @@ class MockResponse(object):
     which has a specific combination of HTTP status code, handle
     response code and content.
     '''
-    def __init__(self, status_code=None, content=None, request=None, success=False, notfound=False, empty=False, wascreated=False):
+    def __init__(self, handle=None, status_code=None, content=None, request=None, success=False, notfound=False, empty=False, wascreated=False):
 
         self.content = None
         self.status_code = None
         self.request = None
 
         # Some predefined cases:
+        if handle is not None and (handle.startswith('hdl:') or handle.startswith('doi:')):
+            self.status_code = 400
         if success:
             self.status_code = 200
             self.content = '{"responseCode":1, "handle":"my/testhandle"}'

--- a/pyhandle/tests/mockresponses.py
+++ b/pyhandle/tests/mockresponses.py
@@ -42,10 +42,11 @@ class MockResponse(object):
             self.content = '{"responseCode":1, "handle":"my/testhandle"}'
         elif notfound:
             self.status_code = 404
-            self.content = '{"responseCode":100}'
+            self.content = '{"responseCode":100, "handle":"my/testhandle"}'
+            # This response to a delete-handle request was verified 2022-06-28 by Merret
         elif empty:
             self.status_code = 200
-            self.content = '{"responseCode":200}'
+            self.content = '{"responseCode":200, "handle":"my/testhandle"}'
         elif wascreated:
             self.status_code = 201
             self.content = '{"responseCode":1, "handle":"my/testhandle"}'
@@ -58,7 +59,7 @@ class MockResponse(object):
             self.request = request
         # Defaults (they do not override):
         if self.content is None:    
-            self.content = '{"responseCode":1}'
+            self.content = '{"responseCode":1, "handle":"my/testhandle"}'
         if self.status_code is None:
             self.status_code = 200
         if self.request is None:

--- a/pyhandle/utilhandle.py
+++ b/pyhandle/utilhandle.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 from . import handleexceptions
 from . import util
 
+
 def remove_index_from_handle(handle_with_index):
     '''
     Returns index and handle separately, in a tuple.
@@ -64,9 +65,13 @@ def check_handle_syntax(string):
 
     if ':' in string:
         if string.startswith('hdl:'): # Fixing https://github.com/EUDAT-B2HANDLE/PYHANDLE/issues/49
-            # TODO: Note: What about DOIs?
-            # TODO: Note of caution: Handle Server won't accept REST API calls with hdl: prepended.
+            # TODO: Note: What about DOIs? -> Fixed in a different PR
+            # Note of caution: Handle Server won't accept REST API calls with hdl: prepended.
+            # It will respond with HTTP Status Code 400 and Response: {"responseCode":301,
+            # "message":"That prefix doesn't live here","handle":"hdl:21.14106/TESTTESTTEST"}
+            # The problem is prevented by removing any hdl: or doi: right before making the request.
             return True
+            
         else:
             check_handle_syntax_with_index(string, base_already_checked=True)
             # TODO: Actually this is not a handle, but refers to a field inside a handle record, so


### PR DESCRIPTION
This addresses issue #25 . Unit tests pass, had to be slightly adapted.

Ideally this should be tested with a real Handle Server too.