### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(name='pyhandle',
       zip_safe=False,
       install_requires=[
           'requests==2.27.1; python_version=="3.5.0"',
-          'requests==2.28.1; python_version>="3.6.0"',
+          'requests>=2.28.1; python_version>="3.6.0"',
           'datetime',
           'future',
           'six',

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(name='pyhandle',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
           'License :: OSI Approved :: Apache Software License',
           'Intended Audience :: Developers',
           'Topic :: Software Development :: Libraries :: Python Modules',
@@ -87,10 +88,10 @@ setup(name='pyhandle',
           'future',
           'six',
           'pymysql==0.8.0 ; python_version < "2.8.0"',
-          'pymysql==0.8.0 ; python_version < "3.11.0"'       
+          'pymysql==0.8.0 ; python_version < "3.12.0"'
       ],
       tests_require=test_dependencies,
-      python_requires='>=3.6, <3.11',
+      python_requires='>=3.6, <3.12',
       cmdclass={'test': NoseTestCommand},
       include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(name='pyhandle',
       install_requires=[
           'requests==2.27.1; python_version=="3.5.0"',
           'requests>=2.28.1; python_version>="3.6.0"',
+          'cython; python_version>="3.10.0"',
           'datetime',
           'future',
           'six',


### PR DESCRIPTION
Made the library compatible and installable on Python 3.11

This was needed as Debian 11 with Python 3.9 is going to be EOL later this year and Debian 12 with Python 3.11 has been out for 7 months now.

Thanks in advance for taking this in consideration.

This is related to #50 